### PR TITLE
Separated dependencies by using 'compileOnly'

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It will register with Testerra Hooking system and uses the event bus to react on
 
 ### Requirements
 
-![Maven Central](https://img.shields.io/maven-central/v/io.testerra/core/1.0-RC-32?label=Testerra)
+![Maven Central](https://img.shields.io/maven-central/v/io.testerra/driver-ui/1.0?label=Testerra)
 
 ### Usage
 
@@ -38,18 +38,29 @@ Gradle:
 
 ````groovy
 implementation 'io.testerra:appium:1.0'
+implementation 'io.testerra:driver-ui:1.0'
+implementation 'io.appium:java-client:7.3.0'
 ````
 
 Maven:
 
-````xml
-
+```xml
 <dependency>
     <groupId>io.testerra</groupId>
     <artifactId>appium</artifactId>
     <version>1.0</version>
 </dependency>
-````
+<dependency>
+    <groupId>io.testerra</groupId>
+    <artifactId>driver-ui</artifactId>
+    <version>1.0</version>
+</dependency>
+<dependency>
+    <groupId>io.appium</groupId>
+    <artifactId>java-client</artifactId>
+    <version>7.3.0/version>
+</dependency>
+```
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It will register with Testerra Hooking system and uses the event bus to react on
 
 ### Requirements
 
-![Maven Central](https://img.shields.io/maven-central/v/io.testerra/driver-ui/1.0?label=Testerra)
+![Maven Central](https://img.shields.io/maven-central/v/io.testerra/driver-ui/1.0-RC-32?label=Testerra)
 
 ### Usage
 

--- a/appium/build.gradle
+++ b/appium/build.gradle
@@ -1,11 +1,12 @@
 dependencies {
     compileOnly 'io.testerra:driver-ui:' + testerraCompileVersion
+    compileOnly 'io.appium:java-client:7.3.0'
 
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.apache.commons:commons-lang3:3.9'
-    implementation 'io.appium:java-client:7.3.0'
 
     testImplementation 'io.testerra:driver-ui:' + testerraTestVersion
+    testImplementation 'io.appium:java-client:7.3.0'
 }
 
 test() {


### PR DESCRIPTION
With this `compileOnly` change in dependencies, the project owner is able to change the underlying libraries.