### PR TITLE
Only load grid.properties for tests

### DIFF
--- a/appium/src/main/java/eu/tsystems/mms/tic/testframework/mobile/hook/MobileAppiumHook.java
+++ b/appium/src/main/java/eu/tsystems/mms/tic/testframework/mobile/hook/MobileAppiumHook.java
@@ -41,7 +41,6 @@ public class MobileAppiumHook implements ModuleHook {
 
     @Override
     public void init() {
-        PropertyManager.loadProperties("grid.properties");
         WebDriverManager.registerWebDriverFactory(new AppiumDriverFactory(), MobileBrowsers.mobile_chrome, MobileBrowsers.mobile_safari);
         GuiElement.registerGuiElementCoreFactory(new AppiumGuiElementCoreFactory(), MobileBrowsers.mobile_chrome, MobileBrowsers.mobile_safari);
     }

--- a/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/test/AbstractAppiumTest.java
+++ b/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/test/AbstractAppiumTest.java
@@ -22,9 +22,11 @@
 
 package eu.tsystems.mms.tic.testframework.mobile.test;
 
+import eu.tsystems.mms.tic.testframework.common.PropertyManager;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
 import eu.tsystems.mms.tic.testframework.mobile.driver.AppiumDriverManager;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
+import org.testng.annotations.BeforeSuite;
 
 /**
  * Abstract Representation for appioum based testerra test
@@ -38,4 +40,8 @@ public class AbstractAppiumTest extends TesterraTest implements Loggable {
 
     protected AppiumDriverManager appiumDriverManager = new AppiumDriverManager();
 
+    @BeforeSuite
+    public void loadGridProperties() {
+        PropertyManager.loadProperties("grid.properties");
+    }
 }

--- a/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/test/driver/VanillaAppiumDriverTest.java
+++ b/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/test/driver/VanillaAppiumDriverTest.java
@@ -24,6 +24,7 @@ package eu.tsystems.mms.tic.testframework.mobile.test.driver;
 
 import eu.tsystems.mms.tic.testframework.common.PropertyManager;
 import eu.tsystems.mms.tic.testframework.logging.Loggable;
+import eu.tsystems.mms.tic.testframework.mobile.test.AbstractAppiumTest;
 import eu.tsystems.mms.tic.testframework.report.Report;
 import eu.tsystems.mms.tic.testframework.report.TesterraListener;
 import eu.tsystems.mms.tic.testframework.testing.TesterraTest;
@@ -52,7 +53,7 @@ import java.net.URL;
  *
  * @author Eric Kubenka
  */
-public class VanillaAppiumDriverTest extends TesterraTest implements Loggable {
+public class VanillaAppiumDriverTest extends AbstractAppiumTest implements Loggable {
 
     private final String accessKey = PropertyManager.getProperty("tt.mobile.grid.access.key");
     //    protected IOSDriver<IOSElement> driver = null;


### PR DESCRIPTION

# Description

This PR moves loading of `grid.properties` to the abstract test class instead of the general hook.