### PR TITLE
Extend iframe with Check annotation and getText asserts

### DIFF
--- a/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/systemundertest/page/IFramePage.java
+++ b/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/systemundertest/page/IFramePage.java
@@ -12,6 +12,9 @@ public class IFramePage extends AbstractInternetPage {
 
     public final GuiElement textArea = new GuiElement(getWebDriver(), By.id("mce_0"), iframe);
 
+    @Check
+    public final GuiElement iframeBodyElement = new GuiElement(getWebDriver(), By.xpath("//*[@id='tinymce']//p"), iframe);
+
     public IFramePage(WebDriver driver) {
         super(driver);
     }

--- a/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/systemundertest/page/OtherIFramePage.java
+++ b/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/systemundertest/page/OtherIFramePage.java
@@ -9,8 +9,10 @@ import org.openqa.selenium.WebDriver;
 
 public class OtherIFramePage extends Page {
 
+    @Check
     public final GuiElement iframe = new GuiElement(getWebDriver(), By.xpath("//iframe[@src='rot.html']"));
 
+    @Check
     public final GuiElement iframeElem = new GuiElement(getWebDriver(), By.xpath("//body"), iframe);
 
 

--- a/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/test/guielement/MobilePageTest.java
+++ b/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/test/guielement/MobilePageTest.java
@@ -116,22 +116,17 @@ public class MobilePageTest extends AbstractAppiumTest {
 
     @Test
     public void test_iFrame_body_element_text() {
-        final String textExpected = "Your content goes here.";
-
         WebDriver webDriver = WebDriverManager.getWebDriver();
         webDriver.get("https://the-internet.herokuapp.com/iframe");
 
         IFramePage iframePage = PageFactory.create(IFramePage.class, webDriver);
         iframePage.iframeBodyElement.isDisplayed();
-        final String textActual = iframePage.iframeBodyElement.getText();
 
-        Assert.assertEquals(textActual, textExpected, "Text equals.");
+        iframePage.iframeBodyElement.asserts().assertText("Your content goes here.");
     }
 
     @Test
     public void test_iFrame_body_element() {
-        final String textExpected = "ROT";
-
         WebDriver webDriver = WebDriverManager.getWebDriver();
         webDriver.get("https://www.on-design.de/tutor/html5_css3/html5/iframe/iframes01.html");
 
@@ -139,9 +134,6 @@ public class MobilePageTest extends AbstractAppiumTest {
         iframePage.iframe.scrollIntoView();
         iframePage.iframeElem.isDisplayed();
 
-        final String textActual = iframePage.iframeElem.getText();
-
-        Assert.assertEquals(textActual, textExpected, "Text equals.");
-
+        iframePage.iframeElem.asserts().assertText("ROT");
     }
 }

--- a/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/test/guielement/MobilePageTest.java
+++ b/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/test/guielement/MobilePageTest.java
@@ -115,12 +115,33 @@ public class MobilePageTest extends AbstractAppiumTest {
     }
 
     @Test
+    public void test_iFrame_body_element_text() {
+        final String textExpected = "Your content goes here.";
+
+        WebDriver webDriver = WebDriverManager.getWebDriver();
+        webDriver.get("https://the-internet.herokuapp.com/iframe");
+
+        IFramePage iframePage = PageFactory.create(IFramePage.class, webDriver);
+        iframePage.iframeBodyElement.isDisplayed();
+        final String textActual = iframePage.iframeBodyElement.getText();
+
+        Assert.assertEquals(textActual, textExpected, "Text equals.");
+    }
+
+    @Test
     public void test_iFrame_body_element() {
+        final String textExpected = "ROT";
+
         WebDriver webDriver = WebDriverManager.getWebDriver();
         webDriver.get("https://www.on-design.de/tutor/html5_css3/html5/iframe/iframes01.html");
 
         OtherIFramePage iframePage = PageFactory.create(OtherIFramePage.class, webDriver);
         iframePage.iframe.scrollIntoView();
         iframePage.iframeElem.isDisplayed();
+
+        final String textActual = iframePage.iframeElem.getText();
+
+        Assert.assertEquals(textActual, textExpected, "Text equals.");
+
     }
 }

--- a/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/test/guielement/MobilePageTest.java
+++ b/appium/src/test/java/eu/tsystems/mms/tic/testframework/mobile/test/guielement/MobilePageTest.java
@@ -132,7 +132,6 @@ public class MobilePageTest extends AbstractAppiumTest {
 
         OtherIFramePage iframePage = PageFactory.create(OtherIFramePage.class, webDriver);
         iframePage.iframe.scrollIntoView();
-        iframePage.iframeElem.isDisplayed();
 
         iframePage.iframeElem.asserts().assertText("ROT");
     }


### PR DESCRIPTION
# Description

The MobilePageTest contains some tests for elements inside iframes.
I have extended them with test cases that don't work for me. Can you check whether they should work?

What I've changed and my issues with that:
* added @Check to some elements in IFramePage and OtherIFramePage
  * I get failures like `OtherIFramePage: Mandatory GuiElement >iframe< was not found`
* `test_iFrame_body_element_text`: expect text of iframeBodyElement is "Your content goes here."
  * assert fails, textActual is "Your content goes here.;__iframe_id=mce_0_ifr;"
* `test_iFrame_body_element`: getText() of iframeElem
  * I get a Sequence execution timed out caused by java.lang.IllegalStateException
 
(for the last two points I removed the @Check annotation)

## Type of change
none of the above, extended tests to check functionality

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
