### PR TITLE
fix used browser name for Android devices

### DIFF
--- a/appium/src/main/java/eu/tsystems/mms/tic/testframework/mobile/driver/AppiumDriverFactory.java
+++ b/appium/src/main/java/eu/tsystems/mms/tic/testframework/mobile/driver/AppiumDriverFactory.java
@@ -130,7 +130,7 @@ public class AppiumDriverFactory extends WebDriverFactory<AppiumDriverRequest> {
             case MobileBrowsers.mobile_chrome:
 
                 desiredCapabilities.setCapability("deviceQuery", APPIUM_DEVICE_QUERY_ANDROID);
-                desiredCapabilities.setBrowserName(MobileBrowserType.CHROMIUM);
+                desiredCapabilities.setBrowserName(MobileBrowserType.CHROME);
 
                 try {
                     final AndroidDriver<AndroidElement> driver = new AndroidDriver<>(new URL(GRID_URL), desiredCapabilities);


### PR DESCRIPTION
---
name: Fix session creation for Android
about: 
title: 'Fix session creation for Android'
labels: bugfix
assignees: 'sbke-mms'

---

# Description

Use the correct browser name when creating a session with an Android device.

Fixes #10 

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
